### PR TITLE
fix ERC 1155 parser for token error type

### DIFF
--- a/src/server/service/remote-chain-service/parse-transaction.ts
+++ b/src/server/service/remote-chain-service/parse-transaction.ts
@@ -36,7 +36,7 @@ export function parseTransaction(
       maxPriorityFeePerGas:
         tx.maxPriorityFeePerGas && hexToDecimal(tx.maxPriorityFeePerGas),
       maxFeePerGas: tx.maxFeePerGas && hexToDecimal(tx.maxFeePerGas),
-      type: hexToNumber(tx.type),
+      type: tx.type ? hexToNumber(tx.type) : undefined,
       fromAddress: hexToBuffer(tx.from),
       fromAddressHash: hexToBuffer(tx.from),
       // @ts-ignore


### PR DESCRIPTION
## Description

An error occurred when I tried to parse the raw data of the transaction. It's an error related to the hex-to-numeric conversion of the field type.

## Links

- #32 
